### PR TITLE
Docker: Fix timezone issues with TZ env variable and /etc/local volume mapping

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -27,6 +27,12 @@ In case you want to make sure that your ssl certs are kept between stops and sta
 to make it persistent
 {% endhint %}
 
+{% hint style="info" %}
+In order to make sure timestamps in the UI and logs are correct, make sure to configure the TZ env variable and also
+the /etc/localtime volume mapping, as per the examples below. Replace the geo location of TZ with your geo location.
+{% endhint %}
+
+
 {% tabs %}
 {% tab title="Docker (Sqlite)" %}
 ```bash
@@ -35,6 +41,8 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -p 8443:443 \
     -e PUID=1000 \
     -e PGID=1000 \
+    -e TZ=America/Chicago \
+    -v /etc/localtime:/etc/localtime:ro \
     -v /path/to/directory:/config \
     -v /path/to/directory/web:/etc/ssl/web \
     ghcr.io/alexjustesen/speedtest-tracker:latest
@@ -48,12 +56,14 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -p 8443:443 \
     -e PUID=1000 \
     -e PGID=1000 \
-    -e "DB_CONNECTION=mysql" \
-    -e "DB_HOST=" \
-    -e "DB_PORT=3306" \
-    -e "DB_DATABASE=speedtest_tracker" \
-    -e "DB_USERNAME=" \
-    -e "DB_PASSWORD=" \
+    -e TZ=America/Chicago \
+    -e DB_CONNECTION=mysql \
+    -e DB_HOST= \
+    -e DB_PORT=3306 \
+    -e DB_DATABASE=speedtest_tracker \
+    -e DB_USERNAME= \
+    -e DB_PASSWORD= \
+    -v /etc/localtime:/etc/localtime:ro \
     -v /path/to/directory:/config \
     -v /path/to/directory/web:/etc/ssl/web \
     ghcr.io/alexjustesen/speedtest-tracker:latest
@@ -67,12 +77,14 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -p 8443:443 \
     -e PUID=1000 \
     -e PGID=1000 \
-    -e "DB_CONNECTION=pgsql" \
-    -e "DB_HOST=" \
-    -e "DB_PORT=5432" \
-    -e "DB_DATABASE=speedtest_tracker" \
-    -e "DB_USERNAME=" \
-    -e "DB_PASSWORD=" \
+    -e DB_CONNECTION=pgsql \
+    -e DB_HOST= \
+    -e DB_PORT=5432 \
+    -e DB_DATABASE=speedtest_tracker \
+    -e DB_USERNAME= \
+    -e DB_PASSWORD= \
+    -e TZ=America/Chicago \
+    -v /etc/localtime:/etc/localtime:ro \
     -v /path/to/directory:/config \
     -v /path/to/directory/web:/etc/ssl/web \
     ghcr.io/alexjustesen/speedtest-tracker:latest
@@ -95,7 +107,9 @@ services:
         environment:
             - PUID=1000
             - PGID=1000
+            - TZ=America/Chicago
         volumes:
+            - '/etc/localtime:/etc/localtime:ro'
             - '/path/to/directory:/config'
             - '/path/to/directory/web:/etc/ssl/web'
         image: 'ghcr.io/alexjustesen/speedtest-tracker:latest'
@@ -121,7 +135,9 @@ services:
             - DB_DATABASE=speedtest_tracker
             - DB_USERNAME=speedy
             - DB_PASSWORD=password
+            - TZ=America/Chicago
         volumes:
+            - '/etc/localtime:/etc/localtime:ro'
             - '/path/to/directory:/config'
             - '/path/to/directory/web:/etc/ssl/web'
         image: 'ghcr.io/alexjustesen/speedtest-tracker:latest'
@@ -161,7 +177,9 @@ services:
             - DB_DATABASE=speedtest_tracker
             - DB_USERNAME=speedy
             - DB_PASSWORD=password
+            - TZ=America/Chicago
         volumes:
+            - '/etc/localtime:/etc/localtime:ro'
             - '/path/to/directory:/config'
             - '/path/to/directory/web:/etc/ssl/web'
         image: 'ghcr.io/alexjustesen/speedtest-tracker:latest'


### PR DESCRIPTION
Changed the docs for docker configuration, introducing the TZ env variable and the /etc/localtime volume mapping.

This solves a lot of issues that are still being opened by users, reporting wrong cron schedules and timestamps in testing records, etc.