### PR TITLE
Add colon to docker-compose volume name

### DIFF
--- a/getting-started/installation/installation.md
+++ b/getting-started/installation/installation.md
@@ -87,7 +87,7 @@ services:
         volumes:
             - speedtest-db:/var/lib/postgresql/data
 volumes:
-  speedtest-app
+  speedtest-app:
   speedtest-db:
 ```
 {% endtab %}


### PR DESCRIPTION
The volume name for the postgres data volume was missing a semicolon. This update should make copy/paste of the `docker-compose.yml` for postgres a little easier.