### PR TITLE
Update SSL keys location for LSIO Docker image

### DIFF
--- a/getting-started/installation/installation.md
+++ b/getting-started/installation/installation.md
@@ -10,6 +10,8 @@ description: >-
 
 Setting up your environment with Docker Compose is the recommended infrastructure pattern as it'll setup the application and a database for you. SQLite is fine for most installs but we also provide instructions for setting up MariaDB, MySQL and Postgres should you prefer those database drivers.
 
+If you would like to provide your own SSL keys, they must be named `cert.crt` (full chain) and `cert.key` (private key), and mounted in the container folder `/config/keys`.
+
 {% tabs %}
 {% tab title="SQLite" %}
 ```yaml

--- a/getting-started/installation/installation.md
+++ b/getting-started/installation/installation.md
@@ -26,7 +26,7 @@ services:
             - DB_CONNECTION=sqlite
         volumes:
             - /path/to/data:/config
-            - /path/to/directory/web:/etc/ssl/web
+            - /path/to-custom-ssl-keys:/config/keys:ro
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
 ```
@@ -52,7 +52,7 @@ services:
             - DB_PASSWORD=password
         volumes:
             - /path/to/data:/config
-            - /path/to/directory/web:/etc/ssl/web
+            - /path/to-custom-ssl-keys:/config/keys:ro
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
         depends_on:
@@ -92,7 +92,7 @@ services:
             - DB_PASSWORD=password
         volumes:
             - /path/to/data:/config
-            - /path/to/directory/web:/etc/ssl/web
+            - /path/to-custom-ssl-keys:/config/keys:ro
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
         depends_on:
@@ -130,7 +130,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e PGID=1000 \
     -e DB_CONNECTION=sqlite \
     -v /path/to/data:/config \
-    -v /path/to/directory/web:/etc/ssl/web \
+    -v /path/to-custom-ssl-keys:/config/keys:ro \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
@@ -149,7 +149,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e DB_USERNAME= \
     -e DB_PASSWORD= \
     -v /path/to/data:/config \
-    -v /path/to/directory/web:/etc/ssl/web \
+    -v /path/to-custom-ssl-keys:/config/keys:ro \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
@@ -168,7 +168,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e DB_USERNAME= \
     -e DB_PASSWORD= \
     -v /path/to/data:/config \
-    -v /path/to/directory/web:/etc/ssl/web \
+    -v /path/to-custom-ssl-keys:/config/keys:ro \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}

--- a/getting-started/installation/installation.md
+++ b/getting-started/installation/installation.md
@@ -28,7 +28,7 @@ services:
             - DB_CONNECTION=sqlite
         volumes:
             - /path/to/data:/config
-            - /path/to-custom-ssl-keys:/config/keys:ro
+            - /path/to-custom-ssl-keys:/config/keys
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
 ```
@@ -54,7 +54,7 @@ services:
             - DB_PASSWORD=password
         volumes:
             - /path/to/data:/config
-            - /path/to-custom-ssl-keys:/config/keys:ro
+            - /path/to-custom-ssl-keys:/config/keys
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
         depends_on:
@@ -94,7 +94,7 @@ services:
             - DB_PASSWORD=password
         volumes:
             - /path/to/data:/config
-            - /path/to-custom-ssl-keys:/config/keys:ro
+            - /path/to-custom-ssl-keys:/config/keys
         image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
         depends_on:
@@ -132,7 +132,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e PGID=1000 \
     -e DB_CONNECTION=sqlite \
     -v /path/to/data:/config \
-    -v /path/to-custom-ssl-keys:/config/keys:ro \
+    -v /path/to-custom-ssl-keys:/config/keys \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
@@ -151,7 +151,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e DB_USERNAME= \
     -e DB_PASSWORD= \
     -v /path/to/data:/config \
-    -v /path/to-custom-ssl-keys:/config/keys:ro \
+    -v /path/to-custom-ssl-keys:/config/keys \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
@@ -170,7 +170,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e DB_USERNAME= \
     -e DB_PASSWORD= \
     -v /path/to/data:/config \
-    -v /path/to-custom-ssl-keys:/config/keys:ro \
+    -v /path/to-custom-ssl-keys:/config/keys \
     lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}

--- a/getting-started/installation/qnap.md
+++ b/getting-started/installation/qnap.md
@@ -34,7 +34,7 @@ services:
       - DB_PASSWORD=password
     volumes:
       - /path/to-data:/config
-      - /path/to/directory/web:/etc/ssl/web
+      - /path/to-custom-ssl-keys:/config/keys:ro
     image: lscr.io/linuxserver/speedtest-tracker:latest
     networks:
       qnet-network:

--- a/getting-started/installation/qnap.md
+++ b/getting-started/installation/qnap.md
@@ -34,7 +34,7 @@ services:
       - DB_PASSWORD=password
     volumes:
       - /path/to-data:/config
-      - /path/to-custom-ssl-keys:/config/keys:ro
+      - /path/to-custom-ssl-keys:/config/keys
     image: lscr.io/linuxserver/speedtest-tracker:latest
     networks:
       qnet-network:


### PR DESCRIPTION
Per [7](https://github.com/linuxserver/docker-speedtest-tracker/issues/7#issuecomment-1952994358), the location of the SSL keys has changed in the LSIO Docker image. This PR updates the docs to reflect this new location.