### PR TITLE
Use latest tag to match with other db

### DIFF
--- a/getting-started/installation/installation.md
+++ b/getting-started/installation/installation.md
@@ -43,7 +43,7 @@ services:
         volumes:
             - /path/to/data:/config
             - /path/to-custom-ssl-keys:/config/keys
-        image: lscr.io/linuxserver/speedtest-tracker:0.20.6
+        image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
 ```
 {% endtab %}
@@ -170,7 +170,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e APP_TIMEZONE= \
     -v /path/to/data:/config \
     -v /path/to-custom-ssl-keys:/config/keys \
-    lscr.io/linuxserver/speedtest-tracker:0.20.6
+    lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
 
@@ -192,7 +192,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e SPEEDTEST_SERVERS= \
     -v /path/to/data:/config \
     -v /path/to-custom-ssl-keys:/config/keys \
-    lscr.io/linuxserver/speedtest-tracker:0.20.6
+    lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
 
@@ -219,7 +219,7 @@ docker run -d --name speedtest-tracker --restart unless-stopped \
     -e APP_TIMEZONE= \
     -v /path/to/data:/config \
     -v /path/to-custom-ssl-keys:/config/keys \
-    lscr.io/linuxserver/speedtest-tracker:0.20.6
+    lscr.io/linuxserver/speedtest-tracker:latest
 ```
 {% endtab %}
 {% endtabs %}

--- a/getting-started/installation/qnap.md
+++ b/getting-started/installation/qnap.md
@@ -46,7 +46,7 @@ services:
     volumes:
       - /path/to-data:/config
       - /path/to-custom-ssl-keys:/config/keys
-    image: lscr.io/linuxserver/speedtest-tracker:0.20.6
+    image: lscr.io/linuxserver/speedtest-tracker:latest
     networks:
       qnet-network:
         ipv4_address: 192.168.1.3

--- a/other/proxies.md
+++ b/other/proxies.md
@@ -36,7 +36,7 @@ services:
             - "traefik.http.routers.speedtest-tracker.tls=true"
             - "traefik.http.routers.speedtest-tracker.tls.certresolver=yourresolver"
             - "traefik.http.services.speedtest-tracker.loadbalancer.server.port=80"
-        image: lscr.io/linuxserver/speedtest-tracker:0.20.6
+        image: lscr.io/linuxserver/speedtest-tracker:latest
         restart: unless-stopped
 ```
 


### PR DESCRIPTION
Update documentation on docker tag to use `latest` tag to match with MariaDB/Postgres