### PR TITLE
Add Speedtest Tracker App (iOS) to community projects

### DIFF
--- a/other/community-projects.md
+++ b/other/community-projects.md
@@ -11,3 +11,4 @@ description: >-
 
 * [SpeedtestTrackerBot](https://github.com/josephistired/SpeedtestTrackerBot) — SpeedtestTrackerBot is a lightweight Discord bot that integrates with the Speedtest Tracker API to provide real-time network performance data via slash commands like `/latest`, `/stats`, `/result`, and `/run`. It's easy to set up with Docker or systemd.
 * Stream Deck - Use the API to show the most recent result on your Stream Deck. Shoutout to [MartynKeigher](https://github.com/MartynKeigher) on GitHub for [providing](https://github.com/alexjustesen/speedtest-tracker/issues/1191) these instructions.
+* [Speedtest Tracker App (iOS)](https://apps.apple.com/us/app/speedtest-tracker-app/id6755368150) - Speedtest Tracker App is a native iOS client for Speedtest Tracker, which integrates with its API to allow you to perform actions or see stats straight from your phone.


### PR DESCRIPTION
Hi! I built a native iOS client for Speedtest Tracker and wanted to add it under Community Projects for anyone who might find it useful. It integrates with the API and allows actions to be taken or to see stats straight from the app.

The app is free, requires users to bring their own instance, and doesn’t collect or transmit personal data.

This PR adds the App Store link under community clients.