### PR TITLE
update synology docs

### DIFF
--- a/getting-started/installation/using-synology.md
+++ b/getting-started/installation/using-synology.md
@@ -12,30 +12,55 @@ The following directions are for the old "Docker" application, if you're using "
 
 ### Install on a Synology NAS
 
-Open the Docker interface of your Synology Device, search for `ajustesen/speedtest-tracker` in the Registry and download it.
+{% hint style="warning" %}
+This guide assumes you know how to use the old "Docker" application.
+{% endhint %}
 
-![download\_image](https://user-images.githubusercontent.com/92191413/210480118-b15f83af-6617-4a0d-b631-760f419425b9.png)
+{% stepper %}
+{% step %}
+### Download Image
+
+Open the Docker interface of your Synology Device, search for `linuxserver/speedtest-tracker` in the Registry and download it.
+{% endstep %}
+
+{% step %}
+### Create Directory
 
 Create a local directory (i.e. `/volume1/docker/speedtest-tracker`) which later can be mapped to the docker container.
+{% endstep %}
+
+{% step %}
+### Start Image
 
 Launch the image once the download is completed.
+{% endstep %}
 
-![launch\_image](https://user-images.githubusercontent.com/92191413/210480210-baa06b52-c3b0-41a4-b50e-ce7af82d683c.png)
+{% step %}
+### Map Ports
 
 Map the ports to available ports.
 
-![port\_mapping](https://user-images.githubusercontent.com/92191413/210481629-6fa76992-403a-415e-9967-af7b00c97d87.png)
+| Local Port | Container Port |
+| ---------- | -------------- |
+| 8443       | 443            |
+| 8080       | 80             |
 
 {% hint style="info" %}
 Make sure the ports you choose are not used by any other application or DSM service on your device and remember to adjust the Synology Firewall settings accordingly.
 {% endhint %}
+{% endstep %}
+
+{% step %}
+### Map Directory
 
 Map the directory you created earlier to the mount path `/config`.
+{% endstep %}
 
-![volume\_mapping](https://user-images.githubusercontent.com/92191413/210480901-069703e3-c6ab-446c-b53b-8c5ef3c87085.png)
+{% step %}
+### Finish
 
 Review your settings and click "done".
 
-![summary](https://user-images.githubusercontent.com/92191413/210480977-3e24ba39-b23e-463f-acba-0a1aad1e57ec.png)
-
 You can now access Speedtest-Tracker via `http://YOUR_IP_ADDRESS:8080` or `https://YOUR_IP_ADDRESS:8443`.
+{% endstep %}
+{% endstepper %}


### PR DESCRIPTION
There was reference to the old image. updated to the new one and made it a simple stepper without images to avoid confusion.