### PR TITLE
Users can trigger manual Speedtest

### DIFF
--- a/security/authorization.md
+++ b/security/authorization.md
@@ -23,7 +23,7 @@
 
 ### Other
 
-<table><thead><tr><th width="302"></th><th data-type="checkbox">User</th><th data-type="checkbox">Admin</th></tr></thead><tbody><tr><td>Manage API tokens</td><td>false</td><td>true</td></tr><tr><td>Trigger a manual Speedtest</td><td>false</td><td>true</td></tr></tbody></table>
+<table><thead><tr><th width="302"></th><th data-type="checkbox">User</th><th data-type="checkbox">Admin</th></tr></thead><tbody><tr><td>Manage API tokens</td><td>false</td><td>true</td></tr><tr><td>Trigger a manual Speedtest</td><td>true</td><td>true</td></tr></tbody></table>
 
 ***
 


### PR DESCRIPTION
Updated the authorization documentation to indicate that both users and admins can trigger a manual Speedtest, instead of only admins.