### PR TITLE
add: prometheus grafana dashboard

### DIFF
--- a/settings/data-platforms/prometheus.md
+++ b/settings/data-platforms/prometheus.md
@@ -8,6 +8,12 @@ You can configure the Prometheus endpoint so it’s only accessible from specifi
 
 <figure><img src="../../.gitbook/assets/prometheus_settings.png" alt=""><figcaption></figcaption></figure>
 
+### Grafana Dashboard
+
+You can use this community made Grafana Dashboard to visualize your data.
+
+{% embed url="https://github.com/CrazyWolf13/Speedtest-Tracker-Prometheus" %}
+
 ### Data pattern
 
 Speedtest Tracker exports data in two categories: labels and metrics. Labels are used for filtering, while metrics are used for displaying data.


### PR DESCRIPTION
Hi, 
As discussed here by @svenvg93 I'm creating a PR to add my adapted grafana board from influxdbv2 to work with prometheus.

https://github.com/alexjustesen/speedtest-tracker/discussions/2600