### PR TITLE
docs: simplify APP_KEY generation command

### DIFF
--- a/contributing/development-environment.md
+++ b/contributing/development-environment.md
@@ -46,7 +46,7 @@ APP_TIMEZONE=UTC
 ```
 
 {% hint style="info" %}
-Generate the APP\_KEY at with the command; `echo -n 'base64:'; openssl rand -base64 32;`
+Generate the APP\_KEY with: `echo "base64:$(openssl rand -base64 32 2>/dev/null)"`
 {% endhint %}
 
 #### 3. Install Composer dependencies

--- a/getting-started/installation/using-docker-compose.md
+++ b/getting-started/installation/using-docker-compose.md
@@ -21,7 +21,7 @@ Docker run commands can be found on the [Using Docker](using-docker.md) page and
 Run the command below to generate a key, the key is required for [encryption](../../security/encryption.md). Copy this key including the `base64:` prefix and paste it as your `APP_KEY` value.
 
 ```bash
-echo -n 'base64:'; openssl rand -base64 32;
+echo "base64:$(openssl rand -base64 32 2>/dev/null)"
 ```
 {% endstep %}
 

--- a/getting-started/installation/using-docker.md
+++ b/getting-started/installation/using-docker.md
@@ -21,7 +21,7 @@ Docker run commands assume you already have a database installed and configured.
 Run the command below to generate a key, the key is required for [encryption](../../security/encryption.md). Copy this key including the `base64:` prefix and paste it as your `APP_KEY` value.
 
 ```bash
-echo -n 'base64:'; openssl rand -base64 32;
+echo "base64:$(openssl rand -base64 32 2>/dev/null)"
 ```
 {% endstep %}
 
@@ -150,6 +150,6 @@ During the start the container there is a default username and password created.
 {% endstep %}
 {% endstepper %}
 
-[^1]: Generate with: `echo -n 'base64:'; openssl rand -base64 32`
+[^1]: Generate with: `echo "base64:$(openssl rand -base64 32 2>/dev/null)"`
 
 [^2]: The URL where you'll access the app (e.g., `http://localhost:8080`)

--- a/security/encryption.md
+++ b/security/encryption.md
@@ -7,5 +7,9 @@ An application key (`APP_KEY`) is used for encryption. It is a base64 encoded st
 Run the command below to generate your `APP_KEY`.
 
 ```bash
-echo -n 'base64:'; openssl rand -base64 32;
+echo "base64:$(openssl rand -base64 32 2>/dev/null)"
 ```
+
+{% hint style="info" %}
+Some OpenSSL installs print a warning such as `can't open config file: etc/ssl/openssl.cnf` before the generated key. The command above suppresses that warning so you can copy a clean `APP_KEY` value.
+{% endhint %}

--- a/security/encryption.md
+++ b/security/encryption.md
@@ -9,7 +9,3 @@ Run the command below to generate your `APP_KEY`.
 ```bash
 echo "base64:$(openssl rand -base64 32 2>/dev/null)"
 ```
-
-{% hint style="info" %}
-Some OpenSSL installs print a warning such as `can't open config file: etc/ssl/openssl.cnf` before the generated key. The command above suppresses that warning so you can copy a clean `APP_KEY` value.
-{% endhint %}


### PR DESCRIPTION
The existing recommended command risks generating invalid keys

```bash
❯ echo -n 'base64:'; openssl rand -base64 32;
base64:WARNING: can't open config file: etc/ssl/openssl.cnf
NJv8dNoTomXDTKOBbeG8i0+Dk/LjN6ic0773/rFDZUk=
```

This brings stronger string building without risks of including warning in the middle of the generated string.